### PR TITLE
Add support for influxdb 0.11+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ python:
   - "pypy"
 
 env:
-  - INFLUX_VERSION=0.9.6.1
-  - INFLUX_VERSION=0.10.0-1
+  - INFLUX_VERSION=0.9.6.1 INFLUX_URL=http://s3.amazonaws.com/influxdb/influxdb_0.9.6.1_amd64.deb
+  - INFLUX_VERSION=0.10.0-1 INFLUX_URL=http://s3.amazonaws.com/influxdb/influxdb_0.10.0-1_amd64.deb
+  - INFLUX_VERSION=0.13.0 INFLUX_URL=https://dl.influxdata.com/influxdb/releases/influxdb_0.13.0_amd64.deb
 
 before_install:
-  - wget http://s3.amazonaws.com/influxdb/influxdb_${INFLUX_VERSION}_amd64.deb
+  - curl -L -O ${INFLUX_URL}
   - sudo dpkg -i influxdb_${INFLUX_VERSION}_amd64.deb
   - travis_retry sudo service influxdb restart
   - sudo service influxdb status

--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ We're using `graflux` in production with a fairly large setup, ~400k metrics in 
 
 ## Compatibility
 
-Under production load only python 2.7 + InfluxDB 0.9.x have been beat on.
-
-Python 2.7, 3.5 and pypy are tested against InfluxDB 0.9.x and 0.10.2 in the test suite and are planned to be fully supported.
+Python 2.7, 3.5 and pypy are tested against InfluxDB 0.9.6, 0.10.0 and 0.13.0 in the test suite. An official Influx version support policy has yet to be determined and will likely depend on how influx stabilizes post 1.0.
 
 One thing that is interesting to explore is `pypy` I haven't tested it with `graphite-api` yet but in isolated benchmarks against the metric index build/load/query it is 5-10x faster than CPython.
 

--- a/graflux/query_engine.py
+++ b/graflux/query_engine.py
@@ -1,25 +1,43 @@
 from influxdb import InfluxDBClient
 from collections import OrderedDict
+import requests
+from distutils.version import LooseVersion
 
 import re
 
 
+
 # TODO makes sense to abstract this to allow cacheable wrapper implementations
 class QueryEngine(object):
+
+    INFLUX_0_11 = LooseVersion('0.11.0')
+
     def __init__(self, config):
         influx_config = config.get('influxdb', {})
-        self.client = InfluxDBClient(influx_config.get('host', 'localhost'),
-                                     influx_config.get('port', '8086'),
+
+        host = influx_config.get('host', 'localhost')
+        port = influx_config.get('port', '8086')
+        ssl = influx_config.get('ssl', False)
+
+        self.client = InfluxDBClient(host,
+                                     port,
                                      influx_config.get('user', 'root'),
                                      influx_config.get('password', 'root'),
                                      influx_config.get('db', 'graphite'),
-                                     influx_config.get('ssl', 'false'))
+                                     ssl)
 
         self.config = config
         self.aggregate_dict = None
         self.steps = config.get('steps', [])
 
         self.minimum_step = self.steps[0][1] if self.steps else 10  # reasonable default?
+
+        # This is a workaround for the Influx driver not supporting the `/ping` endpoint
+        # correctly, we need the URL so we can hit it directly.
+        self.influx_url = 'https://' if ssl else 'http://'
+        self.influx_url = self.influx_url + host + ':' + str(port)
+
+        self.influx_version = None
 
     def query(self, metrics, start_time, end_time):
         step = self.determine_interval(start_time, end_time)
@@ -44,9 +62,27 @@ class QueryEngine(object):
 
     def show_series(self):
         data = self.client.query('SHOW SERIES')
-        return (r['name'] for r in data.raw['series']) if 'series' in data.raw else []
+
+        if 'series' not in data.raw:
+            return []
+
+        # Influx changed the result format of `SHOW SERIES` in the 0.11 release
+        if self.get_influx_version() >= self.INFLUX_0_11:
+            return (v[0] for v in data.raw['series'][0]['values'])
+        else:
+            return (r['name'] for r in data.raw['series'])
 
     # Private
+
+    def get_influx_version(self):
+        # It appears that the influx python driver does not like the 204 response of the `/ping`
+        # endpoint so we're sending the request directly.
+        if not self.influx_version:
+            version_string = requests.get(self.influx_url + '/ping').headers['X-Influxdb-Version']
+            self.influx_version = LooseVersion(version_string)
+
+        return self.influx_version
+
 
     def build_aggregate_dict(self):
         self.aggregate_dict = OrderedDict(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-influxdb>=2.6.0
+influxdb>=2.12.0
 graphite-api>=1.1.2
 six>=1.10.0

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if sys.version_info >= (3,):
 
 setup(
     name='graflux',
-    version='0.1.0',
+    version='0.2.0',
     url='https://github.com/swoop-inc/graflux',
     license='mit',
     author='Mark Bell',
@@ -19,7 +19,7 @@ setup(
     include_package_data=True,
     platforms='any',
     classifiers=(),
-    install_requires=['graphite_api', 'influxdb>=2.6.0'],
+    install_requires=['graphite_api', 'influxdb>=2.12.0'],
     extras_require={},
     **convert_2_to_3
 )


### PR DESCRIPTION
* Adds support for the new SHOW SERIES response structure in 0.11+
  Support for 0.9/0.10 remains for now, this is handled by hitting the `/ping` endpoint in
  influx to get it's version.

* Updates the influxdb client version requirement - no changes needed just keeping up to date