### PR TITLE
Switch to show measurements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ python:
   - "pypy"
 
 env:
-  - INFLUX_VERSION=0.9.6.1 INFLUX_URL=http://s3.amazonaws.com/influxdb/influxdb_0.9.6.1_amd64.deb
-  - INFLUX_VERSION=0.10.0-1 INFLUX_URL=http://s3.amazonaws.com/influxdb/influxdb_0.10.0-1_amd64.deb
-  - INFLUX_VERSION=0.13.0 INFLUX_URL=https://dl.influxdata.com/influxdb/releases/influxdb_0.13.0_amd64.deb
+  - INFLUX_VERSION=1.1.1 INFLUX_URL=https://dl.influxdata.com/influxdb/releases/influxdb_1.1.1_amd64.deb
 
 before_install:
   - curl -L -O ${INFLUX_URL}

--- a/graflux/metric_lookup.py
+++ b/graflux/metric_lookup.py
@@ -95,7 +95,7 @@ class MetricLookup(object):
         if storage.try_acquire_update_lock():
             log.info('index.build.lock_acquired')
 
-            data = query_engine.show_series()
+            data = query_engine.get_series()
 
             index = MetricIndex()
             for metric in data:

--- a/graflux/query_engine.py
+++ b/graflux/query_engine.py
@@ -60,8 +60,8 @@ class QueryEngine(object):
 
         return result
 
-    def show_series(self):
-        data = self.client.query('SHOW SERIES')
+    def get_series(self):
+        data = self.client.query('SHOW MEASUREMENTS')
 
         if 'series' not in data.raw:
             return []

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if sys.version_info >= (3,):
 
 setup(
     name='graflux',
-    version='0.2.0',
+    version='0.3.0',
     url='https://github.com/swoop-inc/graflux',
     license='mit',
     author='Mark Bell',

--- a/test/query_engine_test.py
+++ b/test/query_engine_test.py
@@ -52,12 +52,12 @@ class QueryEngineTest(unittest.TestCase):
 
         self.assertTrue(self.client.write_points(data))
 
-    def test_show_series_empty_db(self):
+    def test_get_series_empty_db(self):
         self.clean_db()
-        result = self.query_engine.show_series()
+        result = self.query_engine.get_series()
         six.assertCountEqual(self, result, [])
 
-    def test_show_series(self):
+    def test_get_series(self):
         metrics = [
             'test.series.one',
             'test.series.two'
@@ -65,7 +65,7 @@ class QueryEngineTest(unittest.TestCase):
         self.clean_db()
         self.create_test_data(metrics)
 
-        result = self.query_engine.show_series()
+        result = self.query_engine.get_series()
 
         six.assertCountEqual(self, result, metrics)
 


### PR DESCRIPTION
In later influx versions, `SHOW SERIES` is substantially slower than `SHOW MEASUREMENTS`. 

Also drop support for influx < 0.11